### PR TITLE
Address PR #14 review findings: escaping, fail-fast validation, metrics timing

### DIFF
--- a/docs/markdown-output-specification.md
+++ b/docs/markdown-output-specification.md
@@ -36,9 +36,9 @@ The conv2md markdown generation engine produces clean, deterministic markdown fr
 ```
 
 ### YAML Frontmatter
-When metadata is provided, the document begins with YAML frontmatter. Every
-value is emitted as a **double-quoted YAML scalar**, including numbers and
-collections, which are stringified first:
+When non-empty metadata is provided, the document begins with YAML frontmatter.
+Every value is emitted as a **double-quoted YAML scalar**, including numbers
+and collections, which are stringified first:
 
 ```yaml
 ---
@@ -83,7 +83,14 @@ Input `Hello *world* with _emphasis_!` is emitted escaped:
 Hello \*world\* with \_emphasis\_\!
 ```
 
-- Markdown special characters escaped: `` \ ` * _ { } [ ] ( ) # + - . ! | ``
+- Markdown special characters escaped: `` \ ` * _ { } [ ] ( ) # + - . ! | = > ``
+- `\` is escaped first, so the escapes added for the rest cannot be
+  double-escaped or defeated by a caller-supplied backslash
+- `=` and `>` are escaped because they are block-level openers ordinary content
+  can spell by accident: `===` on the line under text makes a setext heading,
+  and a leading `>` makes a blockquote. (`---`, the setext level-2 form, is
+  already covered by the `-` escape.) Both are ASCII punctuation, so the
+  backslash escape renders them as the literal characters the author wrote
 - Content appears on line following speaker line
 - Preserves original line breaks and formatting
 
@@ -100,7 +107,7 @@ def hello():
 - Automatic fence length determination
 - Handles nested backticks by extending fence length
 - Language specification support, restricted to the tag charset
-  `[A-Za-z0-9_+#.-]` with a 32 character cap. The language is interpolated into
+  `[A-Za-z0-9_+#.-]` with a 32-character cap. The language is interpolated into
   the opening fence, so a value outside that charset — one containing a newline
   or backticks, for example — could close its own fence and inject Markdown
   that renders outside the code block. Rejected values fall back to a bare
@@ -180,7 +187,7 @@ def hello():
 - Individual message content checked before processing
 
 ### Total Conversation Limits
-- Total size: 100MB after sanitization
+- Total size: 100MB, measured from the raw UTF-8 content before sanitization
 - Cumulative across all messages in conversation
 
 ### Metadata Limits
@@ -265,7 +272,7 @@ The generation uses a pluggable pipeline architecture:
 
 ### Compatibility
 - Follows GitHub Flavored Markdown specification
-- Compatible with standard markdown parsers
+- Compatible with standard Markdown parsers
 - YAML frontmatter follows Jekyll/Hugo conventions
 
 ## Examples

--- a/src/conv2md/markdown/blocks.py
+++ b/src/conv2md/markdown/blocks.py
@@ -9,6 +9,10 @@ from typing import Optional
 # allowed; the length cap keeps an oversized tag out of the header.
 LANGUAGE_TAG_PATTERN = re.compile(r"[A-Za-z0-9_+#.-]{1,32}")
 
+# Characters escaped inside a date marker heading, backslash first so the
+# escapes added for the rest cannot themselves be re-escaped or defeated.
+DATE_MARKER_ESCAPE_CHARS = ("\\", "#", "*", "_")
+
 
 def determine_fence_length(content: str, min_length: int = 3) -> int:
     """Determine appropriate fence length for code block content.
@@ -76,8 +80,14 @@ def escape_markdown_content(text: str) -> str:
     Returns:
         Text with Markdown special characters escaped
     """
-    # Escape Markdown special characters: \ ` * _ { } [ ] ( ) # + - . ! |
-    escape_chars = "\\`*_{}[]()#+-.!|"
+    # "\" must stay first: the escapes added below are themselves backslashes,
+    # so escaping it later would double-escape them.
+    # "=" and ">" are block-level openers that ordinary content can otherwise
+    # spell by accident or on purpose: "===" on the line under text makes a
+    # setext heading, and a leading ">" makes a blockquote. ("-", the setext
+    # level-2 form, is already covered.) Both are ASCII punctuation, so the
+    # backslash escape renders them as the literal characters the author wrote.
+    escape_chars = "\\`*_{}[]()#+-.!|=>"
     for char in escape_chars:
         text = text.replace(char, f"\\{char}")
     return text
@@ -106,12 +116,24 @@ def create_date_marker(date_str: str) -> str:
     """Create a date marker heading.
 
     Args:
-        date_str: Date string in YYYY-MM-DD format
+        date_str: Date string in YYYY-MM-DD format. Values that are not dates
+            are still rendered, but only ever as heading text: a heading ends
+            at the first line break, so any line break in the value would let
+            the remainder render as arbitrary block-level Markdown.
 
     Returns:
         Formatted date marker as level 2 heading
     """
-    # For date markers, we don't need to escape hyphens since they're in heading context
-    # Only escape truly problematic characters for headings
-    safe_date = date_str.replace("#", "\\#").replace("*", "\\*").replace("_", "\\_")
+    # str.split() with no argument splits on every Unicode whitespace run,
+    # which covers "\n", "\r\n", "\v", "\f", NEL and U+2028/U+2029 - so the
+    # value collapses onto the single line the heading occupies, and leading
+    # and trailing whitespace is dropped.
+    safe_date = " ".join(date_str.split())
+
+    # Hyphens need no escaping in heading context, so the date form survives
+    # unchanged. "\" is escaped first: without it a caller-supplied backslash
+    # would pair with the escapes below and turn them back into live markup.
+    for char in DATE_MARKER_ESCAPE_CHARS:
+        safe_date = safe_date.replace(char, f"\\{char}")
+
     return f"## {safe_date}"

--- a/src/conv2md/markdown/constants.py
+++ b/src/conv2md/markdown/constants.py
@@ -1,8 +1,12 @@
 """Constants for markdown generation."""
 
 # Size limits for content validation
+# Content past this limit is rejected (ContentTooLargeError): a payload this
+# large is a caller error, not something to silently reshape.
 MAX_MESSAGE_CONTENT_SIZE = 10 * 1024 * 1024  # 10MB per message
 MAX_TOTAL_CONVERSATION_SIZE = 100 * 1024 * 1024  # 100MB total conversation
+# Deliberately far smaller, and truncating rather than rejecting: content has
+# already passed validation here, so bound sanitization cost without failing.
 MAX_CONTENT_SANITIZATION_SIZE = 100 * 1024  # 100KB content sanitization limit
 
 # Size limits for metadata and fields

--- a/src/conv2md/markdown/generator.py
+++ b/src/conv2md/markdown/generator.py
@@ -19,6 +19,7 @@ from conv2md.markdown.exceptions import (
     ContentTooLargeError,
 )
 from conv2md.markdown.constants import (
+    MAX_CONTENT_SANITIZATION_SIZE,
     MAX_MESSAGE_CONTENT_SIZE,
     MAX_TOTAL_CONVERSATION_SIZE,
 )
@@ -119,7 +120,7 @@ class MarkdownGenerator:
 
         return lines
 
-    def _build_message_lines(self, messages) -> List[str]:
+    def _build_message_lines(self, messages: List[Message]) -> List[str]:
         """Build markdown lines from conversation messages.
 
         Args:
@@ -230,13 +231,30 @@ class MarkdownGenerator:
             except UnicodeEncodeError as e:
                 raise EncodingError(f"Message {i} has encoding issues: {e}") from e
 
-            # Sanitize content after size validation
-            sanitized_content = sanitize_content(str(message.content))
-
             # Count the raw payload the caller supplied. Sanitized sizes are
             # capped per message, so accumulating those would measure message
             # count rather than payload size.
             total_size += raw_content_size
+
+            # Reject before sanitizing this message: the conversation is already
+            # doomed, so sanitizing it would burn work and emit a misleading
+            # truncation warning for content that is never emitted.
+            if total_size > MAX_TOTAL_CONVERSATION_SIZE:
+                raise ContentTooLargeError(
+                    f"Total conversation size exceeds limit: {total_size} bytes"
+                )
+
+            # Sanitize content after size validation
+            sanitized_content, content_truncated = sanitize_content(
+                str(message.content)
+            )
+            if content_truncated:
+                # Losing the tail of a message is a degraded conversion, not a
+                # failure: report it and keep the remaining messages.
+                self.metrics_collector.record_warning(
+                    f"Message {i} content truncated to "
+                    f"{MAX_CONTENT_SANITIZATION_SIZE} characters"
+                )
 
             sanitized_messages.append(
                 replace(
@@ -245,11 +263,6 @@ class MarkdownGenerator:
                     timestamp=clean_timestamp,
                     content=sanitized_content,
                 )
-            )
-
-        if total_size > MAX_TOTAL_CONVERSATION_SIZE:
-            raise ContentTooLargeError(
-                f"Total conversation size exceeds limit: {total_size} bytes"
             )
 
         logger.debug(

--- a/src/conv2md/markdown/metrics.py
+++ b/src/conv2md/markdown/metrics.py
@@ -19,8 +19,9 @@ class ConversionStatus(Enum):
 class ConversionMetrics:
     """Metrics collected during markdown conversion."""
 
-    # Timing metrics
-    start_time: float = field(default_factory=time.time)
+    # Timing metrics. Monotonic clock readings, not wall-clock timestamps: an
+    # NTP step or DST change must not corrupt duration or processing rate.
+    start_time: float = field(default_factory=time.monotonic)
     end_time: Optional[float] = None
     duration_seconds: Optional[float] = None
 
@@ -41,11 +42,10 @@ class ConversionMetrics:
 
     # Performance metrics
     processing_rate_chars_per_sec: Optional[float] = None
-    memory_peak_mb: Optional[float] = None
 
     def finish(self) -> None:
         """Mark the conversion as finished and calculate final metrics."""
-        self.end_time = time.time()
+        self.end_time = time.monotonic()
         self.duration_seconds = self.end_time - self.start_time
 
         if self.duration_seconds > 0 and self.total_content_size > 0:
@@ -67,7 +67,6 @@ class ConversionMetrics:
             "warnings_issued": self.warnings_issued,
             "status": self.status.value,
             "processing_rate_chars_per_sec": self.processing_rate_chars_per_sec,
-            "memory_peak_mb": self.memory_peak_mb,
         }
 
 
@@ -127,8 +126,6 @@ class MetricsCollector:
         self.current_metrics.output_size = output_size
         self.current_metrics.finish()
 
-        # Log final metrics
-        metrics_dict = self.current_metrics.to_dict()
-        self.logger.info(f"Conversion completed: {metrics_dict}")
-
+        # Caller owns reporting; MarkdownGenerator.generate logs the returned
+        # metrics, so logging them here would duplicate every entry.
         return self.current_metrics

--- a/src/conv2md/markdown/security.py
+++ b/src/conv2md/markdown/security.py
@@ -3,7 +3,7 @@
 import logging
 import re
 from datetime import datetime
-from typing import Dict, Any
+from typing import Dict, Any, Tuple
 from conv2md.markdown.constants import (
     MAX_METADATA_VALUE_LENGTH,
     MAX_SPEAKER_NAME_LENGTH,
@@ -18,9 +18,34 @@ logger = logging.getLogger(__name__)
 # are escaped rather than dropped.
 CONTROL_CHARACTERS = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]")
 
+# Speaker names and timestamps are single-line fields, so newline, carriage
+# return and tab carry no meaning there either: the whole C0 range plus DEL is
+# dropped rather than escaped.
+SINGLE_LINE_CONTROL_CHARACTERS = re.compile(r"[\x00-\x1F\x7F]")
+
 # Calendar date with bounded month and day fields. Field bounds alone cannot
 # reject dates such as 2024-02-30, so callers also confirm with the calendar.
 _DATE_PATTERN = r"\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])"
+
+# Timestamp shapes accepted by validate_timestamp, compiled once at import:
+# the validator runs per message, so rebuilding these per call is pure overhead.
+# ISO8601 (2024-08-18T14:30:00Z, 2024-08-18T14:30:00+00:00, 2024-08-18)
+_ISO8601_PATTERN = re.compile(
+    rf"^{_DATE_PATTERN}(?:T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d"
+    r"(?:\.\d+)?(?:[+-]\d{2}:\d{2}|Z)?)?$"
+)
+# Human readable with spaces (2024-08-18 14:30:00)
+_HUMAN_READABLE_PATTERN = re.compile(
+    rf"^{_DATE_PATTERN}\s+(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d$"
+)
+# Time only, 24-hour: 00-23:00-59:00-59 (14:30:00, 14:30, 02:30:45)
+_TIME_24H_PATTERN = re.compile(r"^(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?$")
+# Time only, 12-hour: 01-12:00-59 AM/PM (2:30 PM)
+_TIME_12H_PATTERN = re.compile(
+    r"^(?:0?[1-9]|1[0-2]):[0-5]\d(?::[0-5]\d)?\s*[APap][Mm]$"
+)
+# Unix timestamp (1692364200, 1692364200.123)
+_UNIX_PATTERN = re.compile(r"^\d{10}(?:\.\d{1,6})?$")
 
 
 def sanitize_yaml_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
@@ -89,28 +114,34 @@ def sanitize_yaml_value(value: Any) -> str:
     return f'"{str_value}"'
 
 
-def sanitize_content(content: str) -> str:
+def sanitize_content(content: str) -> Tuple[str, bool]:
     """Sanitize content for safe markdown output.
 
     Args:
         content: Raw content string
 
     Returns:
-        Sanitized content safe for markdown
+        A ``(content, truncated)`` pair. ``truncated`` reports whether the input
+        exceeded MAX_CONTENT_SANITIZATION_SIZE and so lost characters. Silently
+        dropping the caller's text would be invisible, so the signal is returned
+        alongside the text rather than left for the caller to recompute.
     """
     if not content:
-        return ""
+        return "", False
 
     # Limit content length to prevent DoS
+    truncated = len(content) > MAX_CONTENT_SANITIZATION_SIZE
     content = content[:MAX_CONTENT_SANITIZATION_SIZE]
 
     # Remove null bytes and other control characters (except newlines and tabs)
     content = CONTROL_CHARACTERS.sub("", content)
 
-    # Normalize line endings
+    # Normalize line endings. A "\r\n" pair split by the cut above cannot leave
+    # a stray "\r" behind: the second replace maps a lone "\r" to the same "\n"
+    # the intact pair would have produced.
     content = content.replace("\r\n", "\n").replace("\r", "\n")
 
-    return content
+    return content, truncated
 
 
 def validate_speaker_name(speaker: str) -> str:
@@ -132,7 +163,7 @@ def validate_speaker_name(speaker: str) -> str:
     speaker = speaker.strip()[:MAX_SPEAKER_NAME_LENGTH]
 
     # Remove control characters
-    speaker = re.sub(r"[\x00-\x1F\x7F]", "", speaker)
+    speaker = SINGLE_LINE_CONTROL_CHARACTERS.sub("", speaker)
 
     if not speaker:
         raise ValueError("Speaker name contains only invalid characters")
@@ -162,36 +193,17 @@ def validate_timestamp(timestamp: str) -> str:
         return ""
 
     # Remove control characters
-    timestamp = re.sub(r"[\x00-\x1F\x7F]", "", timestamp)
-
-    # Improved validation for common timestamp formats
-    # Pattern 1: ISO8601 formats (2024-08-18T14:30:00Z, etc.)
-    iso8601_pattern = (
-        rf"^{_DATE_PATTERN}(?:T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d"
-        r"(?:\.\d+)?(?:[+-]\d{2}:\d{2}|Z)?)?$"
-    )
-
-    # Pattern 2: Time only formats (14:30:00, 14:30, 2:30 PM, 02:30:45)
-    # 24-hour: 00-23:00-59:00-59, 12-hour: 01-12:00-59 AM/PM
-    time_24h_pattern = r"^(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?$"
-    time_12h_pattern = r"^(?:0?[1-9]|1[0-2]):[0-5]\d(?::[0-5]\d)?\s*[APap][Mm]$"
-
-    # Pattern 3: Unix timestamp (1692364200, 1692364200.123)
-    unix_pattern = r"^\d{10}(?:\.\d{1,6})?$"
-
-    # Pattern 4: Human readable with spaces (2024-08-18 14:30:00)
-    human_readable_pattern = rf"^{_DATE_PATTERN}\s+(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d$"
+    timestamp = SINGLE_LINE_CONTROL_CHARACTERS.sub("", timestamp)
 
     has_calendar_date = bool(
-        re.match(iso8601_pattern, timestamp)
-        or re.match(human_readable_pattern, timestamp)
+        _ISO8601_PATTERN.match(timestamp) or _HUMAN_READABLE_PATTERN.match(timestamp)
     )
 
     if not (
         has_calendar_date
-        or re.match(time_24h_pattern, timestamp)
-        or re.match(time_12h_pattern, timestamp)
-        or re.match(unix_pattern, timestamp)
+        or _TIME_24H_PATTERN.match(timestamp)
+        or _TIME_12H_PATTERN.match(timestamp)
+        or _UNIX_PATTERN.match(timestamp)
     ):
         raise ValueError(f"Invalid timestamp format: {timestamp}")
 

--- a/summary/2026-08-01-review-hardening.md
+++ b/summary/2026-08-01-review-hardening.md
@@ -1,0 +1,55 @@
+# Development Summary — 2026-08-01 (review hardening)
+
+## [2026-08-01 14:15] Commit Summary
+
+**Change Type:** Fix
+**Scope:** markdown module (blocks, security, generator, metrics, constants), docs
+
+**Summary:**
+Second round of PR review findings, verified against current code before action.
+17 findings triaged: 15 valid and fixed, 2 rejected as factually wrong.
+
+Behavioral fixes:
+- `escape_markdown_content` now escapes `=` and `>`, so setext H1 (`===`) and
+  blockquotes cannot be produced from ordinary content. `-` was already escaped,
+  so setext H2 was already unreachable — only the `===` and `>` gaps were real.
+- `create_date_marker` collapsed line breaks and escaped backslashes. Proven
+  weakness: a `date_str` containing a newline broke out of the heading and
+  injected a live code fence.
+- Total-conversation-size validation now fails fast, rejecting on the first
+  message that crosses the limit *before* sanitizing it, rather than after the
+  loop. Previously the entire oversized conversation was sanitized and
+  materialized before being discarded.
+- `sanitize_content` returns `(content, truncated)`; the generator records a
+  metrics warning naming the message index and limit when content is truncated,
+  and continues (status PARTIAL) rather than failing.
+- `ConversionMetrics` timing uses `time.monotonic()` so duration and rate stay
+  valid across wall-clock changes. `memory_peak_mb` was declared and serialized
+  but never assigned — removed rather than half-implemented (YAGNI).
+- Removed duplicate metrics logging from `finish_conversion`; `generate()` is
+  the single owner. Note this moves metrics reporting from INFO to DEBUG.
+
+Non-behavioral: module-scope compiled timestamp patterns, a shared
+control-character constant, a `List[Message]` annotation, constants documenting
+the reject-vs-truncate distinction, and four documentation corrections.
+
+**Rejected findings:**
+- "Normalize line endings before truncating so CRLF pairs are not split."
+  Not a defect: normalization is `.replace("\r\n","\n").replace("\r","\n")`, so
+  the second replace maps an orphaned `\r` to the same `\n` the intact pair would
+  have produced. A sweep of every cut offset from -4 to +4 found no offset
+  leaving a stray `\r`. Documented the invariant and added a regression test.
+- "Fix the code span around `: ` to remove edge whitespace." Not a defect:
+  CommonMark strips a space from each side only when the content both begins and
+  ends with a space. The content begins with a colon, so it already renders
+  correctly; the suggested change would have introduced a bug.
+
+**Verification:**
+- 137 tests pass (was 108 on develop) — 29 added
+- `black --check` and `flake8` both exit 0
+- End-to-end: `=`/`>` escaped, date-marker injection neutralized, fail-fast
+  raises at 300000 bytes on message 1 without sanitizing it, one truncation
+  warning recorded with status PARTIAL
+
+**References:**
+- PR: GH-14 review findings (develop -> main)

--- a/tests/unit/test_markdown_blocks.py
+++ b/tests/unit/test_markdown_blocks.py
@@ -1,6 +1,7 @@
 """Unit tests for Markdown blocks functionality."""
 
 import unittest
+from conv2md.domain.models import ContentType, Message
 from conv2md.markdown.blocks import (
     determine_fence_length,
     create_code_block,
@@ -8,6 +9,7 @@ from conv2md.markdown.blocks import (
     format_speaker_line,
     create_date_marker,
 )
+from conv2md.markdown.pipeline import ImageContentProcessor, TextContentProcessor
 
 
 class TestMarkdownBlocks(unittest.TestCase):
@@ -86,9 +88,9 @@ class TestMarkdownBlocks(unittest.TestCase):
 
     def test_escape_markdown_content_all_special_chars(self):
         """Test escaping all markdown special characters."""
-        text = "\\`*_{}[]()#+-.!|"
+        text = "\\`*_{}[]()#+-.!|=>"
         result = escape_markdown_content(text)
-        expected = "\\\\\\`\\*\\_\\{\\}\\[\\]\\(\\)\\#\\+\\-\\.\\!\\|"
+        expected = "\\\\\\`\\*\\_\\{\\}\\[\\]\\(\\)\\#\\+\\-\\.\\!\\|\\=\\>"
         self.assertEqual(result, expected)
 
     def test_format_speaker_line_simple(self):
@@ -197,6 +199,116 @@ class TestCodeBlockLanguageValidation(unittest.TestCase):
 
         self.assertEqual(result, f"````\n{content}\n````")
         self.assertNotIn("FORGED", result)
+
+
+class TestBlockOpenerEscaping(unittest.TestCase):
+    """Test that content cannot spell a block-level Markdown opener."""
+
+    def test_block_openers_are_escaped(self):
+        """Setext underlines and blockquote markers survive as literal text."""
+        cases = [
+            ("setext h1 underline", "===", "\\=\\=\\="),
+            ("setext h2 underline", "---", "\\-\\-\\-"),
+            ("blockquote", "> text", "\\> text"),
+            ("nested blockquote", ">> text", "\\>\\> text"),
+            ("lazy setext heading", "Title\n===", "Title\n\\=\\=\\="),
+            ("prose equals", "x = 1", "x \\= 1"),
+            ("prose greater than", "a > b", "a \\> b"),
+        ]
+
+        for description, content, expected in cases:
+            with self.subTest(case=description):
+                self.assertEqual(escape_markdown_content(content), expected)
+
+    def test_speaker_line_escapes_block_openers(self):
+        """format_speaker_line inherits the widened escape set."""
+        result = format_speaker_line("> Bot", "12:00 => 13:00")
+        self.assertEqual(result, "**\\> Bot — 12:00 \\=\\> 13:00**")
+
+    def test_text_processor_escapes_block_openers(self):
+        """TextContentProcessor inherits the widened escape set."""
+        message = Message(speaker="User", content="> quoted\n===")
+        result = TextContentProcessor().process(message)
+        self.assertEqual(result, "\\> quoted\n\\=\\=\\=")
+
+    def test_image_processor_escapes_block_openers(self):
+        """ImageContentProcessor inherits the widened escape set."""
+        message = Message(
+            speaker="User",
+            content="a=b>c.png",
+            content_type=ContentType.IMAGE,
+        )
+        result = ImageContentProcessor().process(message)
+        self.assertEqual(result, "![Image](a\\=b\\>c\\.png)")
+
+
+class TestDateMarkerHardening(unittest.TestCase):
+    """Test that create_date_marker confines input to the heading."""
+
+    def test_line_breaks_cannot_escape_the_heading(self):
+        """Every Unicode line break collapses to a space, keeping one line."""
+        cases = [
+            ("newline", "2024-01-01\n# Forged", "## 2024-01-01 \\# Forged"),
+            ("carriage return", "2024-01-01\r# Forged", "## 2024-01-01 \\# Forged"),
+            ("crlf", "2024-01-01\r\n# Forged", "## 2024-01-01 \\# Forged"),
+            ("blank line", "2024-01-01\n\ntext", "## 2024-01-01 text"),
+            ("line separator", "2024-01-01\u2028text", "## 2024-01-01 text"),
+            ("paragraph separator", "2024-01-01\u2029text", "## 2024-01-01 text"),
+            ("vertical tab", "2024-01-01\vtext", "## 2024-01-01 text"),
+            ("form feed", "2024-01-01\ftext", "## 2024-01-01 text"),
+            ("next line", "2024-01-01\x85text", "## 2024-01-01 text"),
+        ]
+
+        for description, date_str, expected in cases:
+            with self.subTest(case=description):
+                result = create_date_marker(date_str)
+                self.assertEqual(result, expected)
+                self.assertEqual(len(result.splitlines()), 1)
+
+    def test_code_fence_injection_stays_inside_the_heading(self):
+        """A fenced block smuggled through a newline cannot open a block."""
+        result = create_date_marker("2024-01-01\n\n```\nrm -rf /\n```")
+
+        self.assertEqual(len(result.splitlines()), 1)
+        self.assertTrue(result.startswith("## "))
+        self.assertEqual(result, "## 2024-01-01 ``` rm -rf / ```")
+
+    def test_backslashes_cannot_defeat_the_escapes(self):
+        """A caller backslash is escaped first so it cannot re-arm markup."""
+        cases = [
+            ("bare backslash", "2024\\01", "## 2024\\\\01"),
+            ("trailing backslash", "2024-01-01\\", "## 2024-01-01\\\\"),
+            ("backslash before star", "a\\*b*c", "## a\\\\\\*b\\*c"),
+            ("backslash before hash", "\\#Forged", "## \\\\\\#Forged"),
+            ("double backslash", "a\\\\b", "## a\\\\\\\\b"),
+        ]
+
+        for description, date_str, expected in cases:
+            with self.subTest(case=description):
+                self.assertEqual(create_date_marker(date_str), expected)
+
+    def test_non_date_input_renders_as_heading_text(self):
+        """Arbitrary values still render, but only ever as heading text."""
+        cases = [
+            ("empty", "", "## "),
+            ("whitespace only", "   \n\t ", "## "),
+            ("surrounding whitespace", "  2024-01-01  ", "## 2024-01-01"),
+            ("not a date", "tomorrow", "## tomorrow"),
+            ("heading marker", "###### deep", "## \\#\\#\\#\\#\\#\\# deep"),
+            ("emphasis", "2024*01*01", "## 2024\\*01\\*01"),
+            ("underscores", "2024_01_01", "## 2024\\_01\\_01"),
+            ("path traversal", "../../etc/passwd", "## ../../etc/passwd"),
+        ]
+
+        for description, date_str, expected in cases:
+            with self.subTest(case=description):
+                self.assertEqual(create_date_marker(date_str), expected)
+
+    def test_date_marker_is_deterministic(self):
+        """Repeated calls on hostile input produce identical output."""
+        date_str = "2024-01-01\n\n# Forged\\*"
+        results = {create_date_marker(date_str) for _ in range(5)}
+        self.assertEqual(len(results), 1)
 
 
 class TestDeterministicOutput(unittest.TestCase):

--- a/tests/unit/test_markdown_generator.py
+++ b/tests/unit/test_markdown_generator.py
@@ -265,6 +265,41 @@ class TestMarkdownGenerator(unittest.TestCase):
         content_line = result.split("\n")[1]
         self.assertEqual(len(content_line), MAX_CONTENT_SANITIZATION_SIZE)
 
+    def test_content_truncation_records_one_warning_and_continues(self):
+        """Truncation is a warned, partial success - never a silent loss."""
+        from unittest.mock import patch
+
+        cases = [
+            ("under limit", MAX_CONTENT_SANITIZATION_SIZE - 1, 0),
+            ("at limit", MAX_CONTENT_SANITIZATION_SIZE, 0),
+            ("over limit", MAX_CONTENT_SANITIZATION_SIZE + 1, 1),
+        ]
+
+        for label, content_length, expected_warnings in cases:
+            with self.subTest(case=label):
+                generator = MarkdownGenerator()
+                conversation = Conversation(
+                    messages=[Message(speaker="User", content="x" * content_length)]
+                )
+                collector = generator.metrics_collector
+
+                with patch.object(
+                    collector, "record_warning", wraps=collector.record_warning
+                ) as spy:
+                    result = generator.generate(conversation)
+
+                self.assertEqual(spy.call_count, expected_warnings)
+                self.assertEqual(
+                    collector.current_metrics.warnings_issued, expected_warnings
+                )
+                # Conversion continues regardless - warnings never abort
+                self.assertTrue(result.startswith("**User:**"))
+
+                if expected_warnings:
+                    warning = spy.call_args.args[0]
+                    self.assertIn("Message 0", warning)
+                    self.assertIn(str(MAX_CONTENT_SANITIZATION_SIZE), warning)
+
     def test_validation_empty_conversation(self):
         """Test validation with empty conversation."""
         conversation = Conversation(messages=[])
@@ -338,8 +373,10 @@ class TestMarkdownGenerator(unittest.TestCase):
                 generator.generate(conversation)
 
             self.assertIn("Total conversation size exceeds limit", str(cm.exception))
-            # Raw bytes, not the per-message sanitization cap (3 x 102400)
-            self.assertIn("450000 bytes", str(cm.exception))
+            # Fail-fast: the second message is the one that crosses 200KB, so
+            # the third is never sanitized and the reported total is 2 x 150000.
+            # Raw bytes, not the per-message sanitization cap (2 x 102400).
+            self.assertIn("300000 bytes", str(cm.exception))
 
     def test_validation_total_size_counts_raw_content_bytes(self):
         """The total-size guard must bound the payload, not the message count."""

--- a/tests/unit/test_markdown_security.py
+++ b/tests/unit/test_markdown_security.py
@@ -2,10 +2,17 @@
 
 import unittest
 
-from conv2md.markdown.constants import MAX_METADATA_VALUE_LENGTH
+from conv2md.markdown.constants import (
+    MAX_CONTENT_SANITIZATION_SIZE,
+    MAX_METADATA_VALUE_LENGTH,
+    MAX_SPEAKER_NAME_LENGTH,
+    MAX_TIMESTAMP_LENGTH,
+)
 from conv2md.markdown.security import (
+    sanitize_content,
     sanitize_yaml_metadata,
     sanitize_yaml_value,
+    validate_speaker_name,
     validate_timestamp,
 )
 
@@ -147,6 +154,125 @@ class TestMetadataKeySanitization(unittest.TestCase):
         self.assertEqual(result, {"ok": '"kept"'})
 
 
+class TestSpeakerNameValidation(unittest.TestCase):
+    """Test speaker name validation directly, not through the generator."""
+
+    def test_rejects_input_with_no_usable_characters(self):
+        """Empty, blank and control-only names raise with a specific message."""
+        cases = [
+            # (description, raw speaker, expected message fragment)
+            ("empty string", "", "cannot be empty"),
+            ("spaces only", "   ", "cannot be empty"),
+            ("tabs and newlines only", "\t\n\r", "cannot be empty"),
+            # \x0B and \x0C are whitespace to str.strip(), so they are caught by
+            # the emptiness check rather than the control-character check.
+            ("vertical tab and form feed only", "\x0b\x0c", "cannot be empty"),
+            ("control characters only", "\x00\x01\x02", "only invalid characters"),
+            ("delete character only", "\x7f", "only invalid characters"),
+        ]
+
+        for description, raw, expected_fragment in cases:
+            with self.subTest(case=description):
+                with self.assertRaises(ValueError) as caught:
+                    validate_speaker_name(raw)
+                self.assertIn(expected_fragment, str(caught.exception))
+
+    def test_accepts_and_cleans_valid_names(self):
+        """Surrounding whitespace is stripped and control bytes are dropped."""
+        cases = [
+            # (description, raw speaker, expected result)
+            ("plain", "Alice", "Alice"),
+            ("surrounding whitespace", "  Alice  ", "Alice"),
+            ("embedded null byte", "Al\x00ice", "Alice"),
+            ("embedded newline", "Al\nice", "Alice"),
+            ("embedded tab", "Al\tice", "Alice"),
+            ("embedded delete", "Al\x7fice", "Alice"),
+            ("internal spaces kept", "Dr. Jane Doe", "Dr. Jane Doe"),
+            ("unicode kept", "Ana Lopez", "Ana Lopez"),
+        ]
+
+        for description, raw, expected in cases:
+            with self.subTest(case=description):
+                self.assertEqual(validate_speaker_name(raw), expected)
+
+    def test_truncates_names_beyond_the_length_limit(self):
+        """Over-long names are cut to MAX_SPEAKER_NAME_LENGTH."""
+        result = validate_speaker_name("a" * (MAX_SPEAKER_NAME_LENGTH + 50))
+        self.assertEqual(result, "a" * MAX_SPEAKER_NAME_LENGTH)
+
+    def test_name_at_the_length_limit_is_untouched(self):
+        """A name of exactly the limit survives intact."""
+        exact = "b" * MAX_SPEAKER_NAME_LENGTH
+        self.assertEqual(validate_speaker_name(exact), exact)
+
+
+class TestContentSanitization(unittest.TestCase):
+    """Test content sanitization, including its truncation boundary."""
+
+    def test_empty_content_reports_no_truncation(self):
+        """Falsy content short-circuits to an empty, untruncated result."""
+        self.assertEqual(sanitize_content(""), ("", False))
+
+    def test_truncation_boundary(self):
+        """Truncation begins only past MAX_CONTENT_SANITIZATION_SIZE."""
+        cases = [
+            # (description, input length, expected truncated flag)
+            ("one below the limit", MAX_CONTENT_SANITIZATION_SIZE - 1, False),
+            ("exactly at the limit", MAX_CONTENT_SANITIZATION_SIZE, False),
+            ("one above the limit", MAX_CONTENT_SANITIZATION_SIZE + 1, True),
+            ("far above the limit", MAX_CONTENT_SANITIZATION_SIZE * 2, True),
+        ]
+
+        for description, length, expected_truncated in cases:
+            with self.subTest(case=description):
+                content, truncated = sanitize_content("a" * length)
+                self.assertEqual(truncated, expected_truncated)
+                self.assertEqual(
+                    len(content), min(length, MAX_CONTENT_SANITIZATION_SIZE)
+                )
+                self.assertEqual(content, "a" * len(content))
+
+    def test_strips_control_characters_but_keeps_whitespace(self):
+        """Control bytes are dropped; newline and tab carry meaning and stay."""
+        cases = [
+            # (description, raw content, expected content)
+            ("null byte", "a\x00b", "ab"),
+            ("start of heading", "a\x01b", "ab"),
+            ("vertical tab", "a\x0bb", "ab"),
+            ("form feed", "a\x0cb", "ab"),
+            ("delete", "a\x7fb", "ab"),
+            ("newline kept", "a\nb", "a\nb"),
+            ("tab kept", "a\tb", "a\tb"),
+        ]
+
+        for description, raw, expected in cases:
+            with self.subTest(case=description):
+                self.assertEqual(sanitize_content(raw), (expected, False))
+
+    def test_normalizes_line_endings(self):
+        """CRLF and lone CR both collapse to LF."""
+        cases = [
+            ("crlf", "a\r\nb", "a\nb"),
+            ("lone cr", "a\rb", "a\nb"),
+            ("mixed", "a\r\nb\rc\nd", "a\nb\nc\nd"),
+            ("trailing crlf", "a\r\n", "a\n"),
+        ]
+
+        for description, raw, expected in cases:
+            with self.subTest(case=description):
+                self.assertEqual(sanitize_content(raw), (expected, False))
+
+    def test_crlf_split_by_truncation_leaves_no_stray_carriage_return(self):
+        """A CRLF pair cut in half must not surface a lone CR in the output."""
+        # Place "\r" at the last kept index and "\n" just past the cut.
+        raw = "a" * (MAX_CONTENT_SANITIZATION_SIZE - 1) + "\r\n" + "bbbb"
+        content, truncated = sanitize_content(raw)
+
+        self.assertTrue(truncated)
+        self.assertNotIn("\r", content)
+        self.assertTrue(content.endswith("a\n"))
+
+
 class TestTimestampValidation(unittest.TestCase):
     """Test timestamp validation functionality."""
 
@@ -260,7 +386,7 @@ class TestTimestampValidation(unittest.TestCase):
         # Very long valid timestamp should be truncated but still valid
         long_valid_timestamp = "2024-08-18T14:30:00.123456789012345678901234567890Z"
         result = validate_timestamp(long_valid_timestamp)
-        self.assertLessEqual(len(result), 50)  # MAX_TIMESTAMP_LENGTH
+        self.assertLessEqual(len(result), MAX_TIMESTAMP_LENGTH)
 
         # Long invalid timestamp should fail validation
         long_invalid_timestamp = "2024-08-18T14:30:00Z" + "x" * 100

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,164 @@
+"""Unit tests for conversion metrics collection."""
+
+import dataclasses
+import time
+import unittest
+from unittest.mock import patch
+
+from conv2md.markdown.metrics import (
+    ConversionMetrics,
+    ConversionStatus,
+    MetricsCollector,
+)
+
+
+def _start_time_field():
+    """Return the dataclass field descriptor for start_time."""
+    fields = {f.name: f for f in dataclasses.fields(ConversionMetrics)}
+    return fields["start_time"]
+
+
+class TestConversionMetricsClock(unittest.TestCase):
+    """Timing must come from the monotonic clock, not the wall clock."""
+
+    def test_start_time_defaults_to_monotonic_clock(self):
+        """start_time is seeded by time.monotonic, never by time.time."""
+        default_factory = _start_time_field().default_factory
+
+        self.assertIs(default_factory, time.monotonic)
+        self.assertIsNot(default_factory, time.time)
+
+    def test_finish_uses_monotonic_clock(self):
+        """Given a finished conversion, end_time reads time.monotonic()."""
+        metrics = ConversionMetrics(start_time=0.0)
+
+        with patch("conv2md.markdown.metrics.time.monotonic", return_value=2000.0):
+            metrics.finish()
+
+        self.assertEqual(metrics.end_time, 2000.0)
+
+    def test_duration_survives_backwards_wall_clock_step(self):
+        """A wall-clock jump backwards must not corrupt duration or rate."""
+        metrics = ConversionMetrics(start_time=500.0)
+        metrics.total_content_size = 100
+
+        # time.time() moving backwards (NTP step / DST) is irrelevant because
+        # neither endpoint is read from the wall clock.
+        with patch("conv2md.markdown.metrics.time.monotonic", return_value=502.5):
+            with patch("conv2md.markdown.metrics.time.time", return_value=0.0):
+                metrics.finish()
+
+        self.assertEqual(metrics.duration_seconds, 2.5)
+        self.assertEqual(metrics.processing_rate_chars_per_sec, 40.0)
+
+    def test_real_clock_produces_non_negative_duration(self):
+        """Given/When/Then: real timings stay ordered and non-negative."""
+        metrics = ConversionMetrics()
+        metrics.finish()
+
+        self.assertIsNotNone(metrics.end_time)
+        self.assertGreaterEqual(metrics.end_time, metrics.start_time)
+        self.assertGreaterEqual(metrics.duration_seconds, 0.0)
+
+
+class TestConversionMetricsCalculation(unittest.TestCase):
+    """Duration and rate calculation behaviour must be preserved."""
+
+    def test_processing_rate_guard_conditions(self):
+        """Rate is only computed for a positive duration and content size."""
+        cases = [
+            ("no duration, no content", 0.0, 0, None),
+            ("no duration, with content", 0.0, 100, None),
+            ("with duration, no content", 2.0, 0, None),
+            ("with duration and content", 2.0, 100, 50.0),
+        ]
+
+        for label, duration, content_size, expected_rate in cases:
+            with self.subTest(case=label):
+                metrics = ConversionMetrics(start_time=10.0)
+                metrics.total_content_size = content_size
+
+                with patch(
+                    "conv2md.markdown.metrics.time.monotonic",
+                    return_value=10.0 + duration,
+                ):
+                    metrics.finish()
+
+                self.assertEqual(metrics.duration_seconds, duration)
+                self.assertEqual(metrics.processing_rate_chars_per_sec, expected_rate)
+
+
+class TestConversionMetricsSerialization(unittest.TestCase):
+    """to_dict() must expose only measured fields."""
+
+    def test_to_dict_keys(self):
+        """The exported payload has an exact, stable key set."""
+        metrics = ConversionMetrics()
+        metrics.finish()
+
+        self.assertEqual(
+            set(metrics.to_dict()),
+            {
+                "duration_seconds",
+                "message_count",
+                "total_content_size",
+                "output_size",
+                "code_blocks_processed",
+                "images_processed",
+                "text_messages_processed",
+                "errors_encountered",
+                "warnings_issued",
+                "status",
+                "processing_rate_chars_per_sec",
+            },
+        )
+
+    def test_to_dict_omits_unmeasured_memory_field(self):
+        """memory_peak_mb is not reported because it is never measured."""
+        metrics = ConversionMetrics()
+
+        self.assertNotIn("memory_peak_mb", metrics.to_dict())
+        self.assertFalse(hasattr(metrics, "memory_peak_mb"))
+
+
+class TestMetricsCollectorLogging(unittest.TestCase):
+    """finish_conversion finalizes metrics without reporting them."""
+
+    def test_finish_conversion_does_not_log_metrics(self):
+        """The caller logs the returned metrics, so this must stay silent."""
+        collector = MetricsCollector()
+        collector.start_conversion()
+
+        with self.assertLogs(collector.logger, level="DEBUG") as captured:
+            # Emit one record so assertLogs has something to assert against.
+            collector.logger.debug("probe")
+            collector.finish_conversion(output_size=42)
+
+        self.assertEqual(
+            [record.getMessage() for record in captured.records], ["probe"]
+        )
+
+    def test_finish_conversion_finalizes_and_returns_metrics(self):
+        """Output size, duration, and status are set on the returned object."""
+        collector = MetricsCollector()
+        started = collector.start_conversion()
+        collector.record_message_processed("text", 10)
+
+        finished = collector.finish_conversion(output_size=42)
+
+        self.assertIs(finished, started)
+        self.assertIs(finished, collector.current_metrics)
+        self.assertEqual(finished.output_size, 42)
+        self.assertIsNotNone(finished.duration_seconds)
+        self.assertEqual(finished.status, ConversionStatus.SUCCESS)
+
+    def test_finish_conversion_without_start_raises(self):
+        """Finishing an unstarted conversion is a programming error."""
+        collector = MetricsCollector()
+
+        with self.assertRaises(ValueError):
+            collector.finish_conversion(output_size=1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Second round of review findings, each verified against current code before action. **17 findings triaged: 15 fixed, 2 rejected as factually wrong.**

## Behavioral fixes

| Area | Change |
|---|---|
| `blocks.py` | Escape `=` and `>` so setext H1 and blockquotes cannot come from ordinary content. `-` was already escaped, so setext H2 was already unreachable — only these two gaps were real. |
| `blocks.py` | `create_date_marker` hardened. **Proven:** a `date_str` with a newline broke out of the heading and injected a live code fence. |
| `generator.py` | Total-size limit now **fails fast** — rejects on the first message crossing the limit, *before* sanitizing it. Previously the whole oversized conversation was sanitized and materialized before being discarded. |
| `generator.py` | Content truncation records a metrics warning (message index + limit), status → `PARTIAL`, conversion continues. |
| `security.py` | `sanitize_content` returns `(content, truncated)` so silent data loss is reportable. |
| `metrics.py` | `time.monotonic()` for both endpoints — wall-clock timing could yield a negative duration on an NTP step. |
| `metrics.py` | `memory_peak_mb` removed: declared and serialized but never assigned, so consumers always got `null`. |

## Rejected findings

**"Normalize line endings before truncating so CRLF pairs are not split."** Not a defect. Normalization is `.replace("\r\n","\n").replace("\r","\n")` — the second replace maps an orphaned `\r` to the same `\n` the intact pair produces. Swept every cut offset from −4 to +4: no offset leaves a stray `\r`. Invariant documented, regression test added.

**"Fix the `: ` code span edge whitespace."** Not a defect. CommonMark strips edge spaces only when content *both* begins and ends with a space; this content begins with a colon, so it already renders correctly. The suggested change would have introduced a bug.

## Risk

Escaping `=` and `>` **changes output** for content containing those characters. Both are ASCII punctuation, so CommonMark renders `\=`/`\>` as literals — no rendering regression, only noisier raw Markdown. One existing assertion was updated (strengthened, not weakened) and the spec doc's escape set now matches.

Metrics reporting moves from INFO to DEBUG as a side effect of removing duplicate logging.

## Verification

- **137 tests pass** (108 on develop — 29 added), integration and contract green
- `black --check src/ tests/` and `flake8 src/ tests/` both exit 0
- End-to-end confirmed: escaping, date-marker injection neutralized, fail-fast raising at 300000 bytes on message 1 without sanitizing it, one truncation warning with status `PARTIAL`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown escaping to prevent unintended headings, blockquotes, and formatting.
  * Prevented line-break and fence injection in date markers.
  * Added fail-fast validation for oversized conversations.
  * Sanitized oversized content with clear truncation warnings.
  * Improved handling of control characters, timestamps, speaker names, and line endings.
  * Improved conversion timing accuracy and reporting consistency.

* **Documentation**
  * Clarified metadata, escaping, validation limits, sanitization, and compatibility requirements.

* **Tests**
  * Expanded coverage for escaping, sanitization, size limits, truncation warnings, and conversion metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->