### PR TITLE
chore(deps): raise dependency floors (supersedes Dependabot #9-#13)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,15 +16,15 @@ dependencies = [
 dev = [
     "black>=22.0.0",
     "flake8>=5.0.0",
-    "safety>=2.0.0",
-    "bandit[toml]>=1.7.0",
+    "safety>=3.7.0",
+    "bandit[toml]>=1.9.4",
     "pip-audit>=2.0.0",
 ]
 plugins = [
-    "requests>=2.28.0",
-    "beautifulsoup4>=4.11.0",
+    "requests>=2.33.1",
+    "beautifulsoup4>=4.14.3",
     "openai>=1.0.0",
-    "pytesseract>=0.3.10",
+    "pytesseract>=0.3.13",
 ]
 
 [project.scripts]

--- a/summary/2026-08-01-dependency-bumps.md
+++ b/summary/2026-08-01-dependency-bumps.md
@@ -1,0 +1,50 @@
+# Development Summary — 2026-08-01 (dependency floor bumps)
+
+## [2026-08-01 14:40] Commit Summary
+
+**Change Type:** Chore
+**Scope:** pyproject.toml dependency declarations
+
+**Summary:**
+Consolidated five Dependabot PRs (GH-9 through GH-13) into a single change,
+raising the declared minimum for five development and plugin dependencies:
+
+| Package | Old floor | New floor | Extra |
+|---|---|---|---|
+| safety | >=2.0.0 | >=3.7.0 | dev |
+| bandit[toml] | >=1.7.0 | >=1.9.4 | dev |
+| requests | >=2.28.0 | >=2.33.1 | plugins |
+| beautifulsoup4 | >=4.11.0 | >=4.14.3 | plugins |
+| pytesseract | >=0.3.10 | >=0.3.13 | plugins |
+
+**Rationale:**
+Consolidated rather than merged individually because all five modify adjacent
+lines of the same file: merging them one at a time would require Dependabot to
+rebase the remaining four after each merge, costing five CI runs to land five
+one-line changes. Dependabot closes its own PRs once it observes the
+requirements updated.
+
+**What this does and does not change:**
+Nothing about what CI actually installs. Because every requirement is an
+unpinned `>=` range, `pip install -e ".[dev]"` already resolves to the newest
+release: the environment was verified to be running bandit 1.9.4, safety 3.8.1
+and requests 2.34.2 — at or above every proposed floor — *before* this change.
+
+The bump therefore only raises the documented minimum. That still matters: it
+records the baseline the project is actually tested against, and stops a
+resolver working from an old cache or a constrained environment from silently
+selecting a years-old release.
+
+Note this is a symptom of the unpinned-dependency debt already recorded in
+`summary/2026-08-01-development-summary.md`. Raising a floor is not a substitute
+for pinning; CI remains non-deterministic across days until versions are pinned
+per CLAUDE.md section 6.
+
+**Verification:**
+- `pip install --dry-run -e ".[dev,plugins]"` resolves with all five floors,
+  confirming no conflict between the plugin and dev dependency sets
+- `pip-audit` reports no known vulnerabilities in the resolved environment
+- 113 tests pass (108 unit, 4 integration, 1 contract); black and flake8 exit 0
+
+**References:**
+- Supersedes: GH-9, GH-10, GH-11, GH-12, GH-13


### PR DESCRIPTION
Consolidates Dependabot PRs #9, #10, #11, #12, #13 into a single change.

| Package | Old floor | New floor | Extra |
|---|---|---|---|
| `safety` | `>=2.0.0` | `>=3.7.0` | dev |
| `bandit[toml]` | `>=1.7.0` | `>=1.9.4` | dev |
| `requests` | `>=2.28.0` | `>=2.33.1` | plugins |
| `beautifulsoup4` | `>=4.11.0` | `>=4.14.3` | plugins |
| `pytesseract` | `>=0.3.10` | `>=0.3.13` | plugins |

## Why consolidated

All five edit adjacent lines of `pyproject.toml`, so merging them individually forces Dependabot to rebase the remaining four after each merge — five CI runs to land five one-line changes. Dependabot closes its own PRs automatically once it observes the requirements updated.

## What this actually changes

**Nothing about what CI installs.** Every requirement is an unpinned `>=` range, so `pip install -e ".[dev]"` already resolves to the newest release. Verified *before* this change, the environment was running:

```
bandit    1.9.4     (proposed floor 1.9.4)
safety    3.8.1     (proposed floor 3.7.0)
requests  2.34.2    (proposed floor 2.33.1)
```

— already at or above every proposed floor. So this raises the *documented* minimum only. That still has value: it records the baseline the project is actually tested against, and stops a resolver working from a stale cache or constrained index silently selecting a years-old release.

> **Worth noting:** this is a symptom of the unpinned-dependency debt recorded in `summary/2026-08-01-development-summary.md`. Raising a floor is not a substitute for pinning — CI stays non-deterministic across days until versions are pinned per CLAUDE.md §6. A `safety` 2.x→3.x floor bump looks like a major-version risk but is not, precisely because CI has been resolving 3.x for months already.

## Verification

- `pip install --dry-run -e ".[dev,plugins]"` resolves with all five floors — confirms the plugin and dev sets have no conflict
- `pip-audit` reports **no known vulnerabilities** in the resolved environment
- 113 tests pass (108 unit, 4 integration, 1 contract); `black` and `flake8` exit 0

## Closes

Supersedes #9, #10, #11, #12, #13.