### PR TITLE
docs: replace fragile code span with prose (PR #17 review finding)

### DIFF
--- a/summary/2026-08-01-review-hardening.md
+++ b/summary/2026-08-01-review-hardening.md
@@ -39,10 +39,11 @@ the reject-vs-truncate distinction, and four documentation corrections.
   the second replace maps an orphaned `\r` to the same `\n` the intact pair would
   have produced. A sweep of every cut offset from -4 to +4 found no offset
   leaving a stray `\r`. Documented the invariant and added a regression test.
-- "Fix the code span around `: ` to remove edge whitespace." Not a defect:
-  CommonMark strips a space from each side only when the content both begins and
-  ends with a space. The content begins with a colon, so it already renders
-  correctly; the suggested change would have introduced a bug.
+- "Fix the code span containing a colon followed by a space, to remove edge
+  whitespace." Not a defect: CommonMark strips a space from each side only when
+  the content both begins and ends with a space. That content begins with a
+  colon, so it already renders correctly; the suggested change would have
+  introduced a bug.
 
 **Verification:**
 - 137 tests pass (was 108 on develop) — 29 added


### PR DESCRIPTION
Addresses the single inline finding on PR #17, `summary/2026-08-01-review-hardening.md:42`.

## Verification

The finding's stated rationale — "contains trailing whitespace" — is **accurate**: the span `` `: ` `` does carry a space just inside the closing delimiter.

But to be precise about *why* that matters, since a similar-sounding finding was rejected earlier:

| Claim | Verdict |
|---|---|
| It renders incorrectly | ❌ **No.** CommonMark strips edge spaces only when content *both* begins and ends with a space. This begins with a colon, so it renders as `: ` exactly. |
| It's a brittle construct | ✅ **Yes.** markdownlint **MD038** (`no-space-in-code`) flags spaces just inside code-span delimiters, and editors and diff tools routinely trim trailing spaces. |

So this is a **robustness and readability fix, not a rendering bug** — and the earlier rejection of the *rendering* claim still stands. The change alters how the explanation is written, not what it concludes.

There's an additional reason prose is better here: the sentence is *itself* about a code span, so nesting the literal inside another one obscured the point.

## Change

```diff
-- "Fix the code span around `: ` to remove edge whitespace." Not a defect:
-  CommonMark strips a space from each side only when the content both begins and
-  ends with a space. The content begins with a colon, so it already renders
-  correctly; the suggested change would have introduced a bug.
+- "Fix the code span containing a colon followed by a space, to remove edge
+  whitespace." Not a defect: CommonMark strips a space from each side only when
+  the content both begins and ends with a space. That content begins with a
+  colon, so it already renders correctly; the suggested change would have
+  introduced a bug.
```

## Not changed

`summary/2026-08-01-development-summary.md:95` contains the same `` `: ` `` construct. Left alone deliberately — it wasn't cited, the brief was to keep changes minimal, and there it appears in a technical sentence about YAML colon handling where the literal genuinely aids comprehension. Happy to align it if you'd prefer consistency.

## Validation

Documentation only, no source touched. 137 tests pass; `black` and `flake8` exit 0.

Once merged to `develop`, PR #17 picks this up automatically.